### PR TITLE
Add plantuml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,79 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  should_build:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_services: ${{ steps.changes.outputs.changed_folders }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # checkout entire history to get changed files in push
+      - name: Get changed folders
+        id: changes
+        run: |
+          changed_folders=$(git diff --name-only --diff-filter=d ${{ github.event.before }} ${{ github.sha }} | \
+            awk -F/ '{print $1}' | \
+            uniq | \
+            grep -Fxf <(find . -name Dockerfile -exec dirname {} \; | awk -F/ '{print $2}') | \
+            xargs)
+          echo "changed_folders=$changed_folders" >> $GITHUB_OUTPUT
+
+  build:
+    if: ${{ needs.should_build.outputs.changed_services != '' }}
+    needs: should_build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set environment variables
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
+          else
+            echo "TAG=latest" >> $GITHUB_ENV
+          fi
+          echo "CONTAINER_REGISTRY=ghcr.io/${{ github.repository_owner }}/" >> $GITHUB_ENV
+      - name: Build Docker image
+        run: |
+          for svc in ${{ needs.should_build.outputs.changed_services }}
+          do
+            docker compose build $svc
+          done
+      - name: Run Trivy image vulnerability scanner
+        run: |
+          for svc in ${{ needs.should_build.outputs.changed_services }}
+          do
+            img=$(docker compose config $svc | grep 'image:' | awk '{print $2}')
+            docker run --rm -v trivy-cache:/root/.cache/ \
+              -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image \
+              --format "table" \
+              --exit-code "1" \
+              --ignore-unfixed \
+              --vuln-type "os,library" \
+              --severity CRITICAL,HIGH $img
+          done
+      - name: Push Docker image
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          for svc in ${{ needs.should_build.outputs.changed_services }}
+          do
+            docker compose push $svc
+          done

--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ This repository contains Dockerfiles for images I use daily or every once in a
 while so I can experiment/use binaries/programs without having to install the
 dependencies. Most of my time is spent developing in a container with vim and
 other dependencies required by the project or application.
+
+All images can be built on your host using `docker compose build <service>` for your
+convenience. See the [compose file](./compose.yml) for the details and environment
+variables to customize the image.
+
+Additionally, all images can be pulled from https://ghcr.io/jmzagorski, using the image name
+and optional tag as the last path parameter. See the table below for more details.
+
+| Dockerfile | Service | Summary | Pull | Running |
+|------------|---------|---------|---------|---------|
+| [Plantuml](./plantuml/Dockerfile) | [plantuml](./compose.yaml#L2) | See https://plantuml.com/ | `docker pull https://ghcr.io/jmzagorski/bin/plantuml` | `cat diagram.puml \| docker run --rm -i ghcr.io/jmzagorski/bin/plantuml > output.svg` |

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  plantuml:
+    build: ./plantuml
+    image: ${CONTAINER_REGISTRY}${PLANTUML_IMAGE:-bin/plantuml}:${TAG:-latest}

--- a/plantuml/Dockerfile
+++ b/plantuml/Dockerfile
@@ -1,0 +1,13 @@
+FROM adoptopenjdk/openjdk16:alpine
+ENV PLANTUML_VERSION=1.2023.13
+ENV LANG en_US.UTF-8
+
+RUN \
+  apk add --no-cache graphviz wget ttf-dejavu fontconfig && \
+  wget "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" -O plantuml.jar && \
+  apk del wget
+
+RUN ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-version"]
+RUN ["dot", "-version"]
+ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "plantuml.jar", "-p"]
+CMD ["-tsvg"]


### PR DESCRIPTION
- Add plantuml docker image as a "bin" service. Use bin for these binary
  type tools
- Use env. variables to provide build customizations for local and remote
- Use github actions to automatically push any docker image that may 
   have changed by assuming any file change in a service needs a re-push. 
   Run a security check to make sure we are running the most up to date & 
   secure image. Only push to github container registry on the main branch 
   with the latest tag since I don't see any reason to maintain versions at the
   moment.