### PR TITLE
feat(puppeteer): Add image for puppeteer dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,18 @@ Images prefixed with **dev** are meant to be a full development environment to
 code with all dependencies for the application/project, VIM, and VIM
 dependencies.
 
+## [examples](./examples)
+I provide some examples on how to setup a container if additional configuration
+is needed or if it improves the container experience. When building images and running
+containers, I use a `.env` file to store personal preferences. See the examples
+for more details.
+
+## Images
+
 
 | Dockerfile | Service | Summary | Running |
 |------------|---------|---------|---------|
 | [Plantuml](./plantuml/Dockerfile) | [plantuml](./compose.yaml#L3) | https://plantuml.com/ | `cat diagram.puml \| docker run --rm -i ghcr.io/jmzagorski/bin/plantuml > output.svg` |
 | [Toilet](./toilet/Dockerfile) | [toilet](./compose.yaml#L7) | http://caca.zoy.org/wiki/toilet/ | `docker run --rm ghcr.io/jmzagorski/bin/toilet -w 200 -f letter Hello World` |
-| [Dotnet](./dotnet/Dockerfile) | [dotnet](./compose.yaml#L11) | Personal [dotnet](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks/) dev environment | `docker run -it --rm ghcr.io/jmzagorski/dev/dotnet bash` or see [compose example](./examples/dotnet-compose.yaml) |
+| [Dotnet](./dotnet/Dockerfile) | [dotnet](./compose.yaml#L11) | Personal [dotnet](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks/) dev environment | `docker run -it --rm ghcr.io/jmzagorski/dev/dotnet bash` or see [compose example](./examples/compose.yamlL#3) |
+| [Puppeteer](./puppeteer//Dockerfile) | [puppeteer](./compose.yaml#L21) | Personal [puppeteer](https://pptr.dev/) dev environment | `docker run -it --rm ghcr.io/jmzagorski/dev/puppeteer bash` or see [compose example](./examples/compose.yaml#L23) |

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,15 @@ services:
     build:
       context: ./dotnet
       args:
-        - USERID=${ARG_USER_ID:-1000}
-        - USER_GROUPID=${ARG_GROUP_ID:-1000}
-        - DOTNET_SDK_VER=${DOTNET_SDK_VER:-6.0}
+        USERID: "${ARG_USER_ID:-1000}"
+        USER_GROUPID: "${ARG_GROUP_ID:-1000}"
+        DOTNET_SDK_VER: "${DOTNET_SDK_VER:-6.0}"
+        VIM_DEPS: "${VIM_DEPS:-universal-ctags ripgrep yamllint}"
     image: ${CONTAINER_REGISTRY}${DOTNET_IMAGE:-dev/dotnet}:${DOTNET_SDK_VER:-6.0}
+
+  puppeteer:
+    build:
+      context: ./puppeteer
+      args:
+        VIM_DEPS: "${VIM_DEPS:-universal-ctags ripgrep yamllint}"
+    image: ${CONTAINER_REGISTRY}${PUPPETEER_IMAGE:-dev/puppeteer}:${TAG:-latest}

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -6,6 +6,7 @@ EXPOSE 5001
 
 ARG USERID
 ARG USER_GROUPID
+ARG VIM_DEPS
 
 RUN groupadd --gid $USER_GROUPID dotnet \
     && useradd --uid $USERID --gid $USER_GROUPID --shell /bin/bash --create-home dotnet
@@ -17,11 +18,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates \
     git \
     gcc \
-    ripgrep \
-    universal-ctags \
-    yamllint \
     ncurses-dev \
-    make
+   make ${VIM_DEPS}
 RUN update-ca-certificates
 RUN git clone https://github.com/vim/vim.git \
     && cd vim \

--- a/examples/Dockerfile.puppeteer
+++ b/examples/Dockerfile.puppeteer
@@ -1,0 +1,17 @@
+FROM ghcr.io/jmzagorski/dev/puppeteer
+
+ARG USER__CA_CERT
+
+COPY ./${USER__CA_CERT} /usr/local/share/ca-certificates/
+ENV NODE_EXTRA_CA_CERTS="/usr/local/share/ca-certificates/${USER__CA_CERT?}"
+# avoid too many progress messages
+ENV CI=1
+
+WORKDIR /home/node/app
+USER node
+COPY --chown=node:node package*.json ./
+RUN npm install
+COPY --chown=node:node ./ .
+EXPOSE 7000
+
+CMD [ "xvfb-run", "--server-args='-screen 0 1024x768x24'", "npm", "start" ]

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -1,6 +1,6 @@
 ---
 services:
-  webapi:
+  dotnet:
     image:  ghcr.io/jmzagorski/dev/dotnet
     #see https://github.com/vishnubob/wait-for-it
     command: ./scripts/wait-for-it.sh db:1433 --timeout=0 -- dotnet watch run --launch-profile "Docker"
@@ -19,6 +19,24 @@ services:
       ASPNETCORE_URLS: "http://0.0.0.0:5000"
     depends_on:
       - db
+
+  puppeteer:
+    build:
+      context: .
+      dockerfile: Dockerfile.puppeteer
+      args:
+        USER__CA_CERT: "${USER__CA_CERT?}"
+    volumes:
+      - .:/home/node/app
+      - ${HOME}/.vim:/home/node/.vim
+      - ${HOME}/.bashrc:/home/node/.bashrc
+      - ${HOME}/.gitconfig:/home/node/.gitconfig
+      - ${HOME}/.git_template:/home/node/.git_template
+    enronment:
+      TERM: "${TERM?}"
+      NODE_ENV: "development"
+      PUPPETEER_EXECUTABLE_PATH: "google-chrome-stable"
+      LANG: "C.UTF-8"
 
   db:
     image: "mcr.microsoft.com/mssql/server"

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/puppeteer/puppeteer:latest
+
+ARG VIM_DEPS
+
+USER root
+RUN apt-get update && \
+   apt-get upgrade -y && \
+   apt-get install --no-install-recommends -y \
+   openssh-client=1:9.2p1-2+deb12u2 \
+   git \
+   gcc \
+   ncurses-dev \
+   xvfb xauth xdg-utils wget \
+   make ${VIM_DEPS}
+RUN git clone https://github.com/vim/vim.git \
+    && cd vim \
+    && make \
+    && make install \
+    && make clean \
+    && cd ../ \
+    && rm -rf vim
+RUN apt remove -y ncurses-dev gcc make && apt autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/node
+USER node
+
+EXPOSE 7000


### PR DESCRIPTION
- Use one compose file in examples since we can differentiate with the service name. This will reduce the number of files in the examples. Use a special Dockerfile name to differentiate images so we don't have to create a directory for each example container
- Add `VIM_DEPS` build arg so that dev images have the same vim dependencies that are required by my VIM setup. This will also allow anyone cloning the repo to customize it as well
- Add full example for puppeteer because it requires the users package.json to install their dependencies